### PR TITLE
Fix broken links in documentation and navigation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -6,5 +6,5 @@
 ---
 
 !!! example "Inizia da qui"
-    - **Analisi 1** → [Limiti](analisi-1/teoria/limiti.md), [Derivate](analisi-1/teoria/derivate.md)
-    - **Algebra Lineare** → [Spazi vettoriali](algebra-lineare/teoria/spazi-vettoriali.md)
+    - **Analisi 1** → [Limiti](analisi-1/teoria/limiti.md)
+    - **Geometria 1** → [Spazi vettoriali](geometria-1/teoria/spazi-vettoriali.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,15 +47,10 @@ nav:
   - Analisi 1:
       - Teoria:
           - Limiti: analisi-1/teoria/limiti.md
-          - Derivate: analisi-1/teoria/derivate.md
-          - Integrali: analisi-1/teoria/integrali.md
       - Esercizi:
           - Limiti: analisi-1/esercizi/limiti-esercizi.md
-          - Derivate: analisi-1/esercizi/derivate-esercizi.md
   - Geometria 1:
       - Teoria:
           - Spazi Vettoriali: geometria-1/teoria/spazi-vettoriali.md
-      - Esercizi:
-          - Spazi Vettoriali: geometria-1/esercizi/spazi-vettoriali-esercizi.md
-          - Fogli di Esercizi:
-              - Foglio 1: geometria-1/fogli/foglio-1.md
+      - Fogli di Esercizi:
+          - Foglio 1: geometria-1/fogli/foglio-1.md


### PR DESCRIPTION
## Summary
- repair broken home page links to existing sections
- prune missing pages from mkdocs navigation

## Testing
- `mkdocs build --site-dir /tmp/site`


------
https://chatgpt.com/codex/tasks/task_e_689611ad629c8326a9a1367439eac5a9