### PR TITLE
Fix vector spaces link in index

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -7,4 +7,4 @@
 
 !!! example "Inizia da qui"
     - **Analisi 1** → [Limiti](analisi-1/teoria/limiti.md), [Derivate](analisi-1/teoria/derivate.md)
-    - **Algebra Lineare** → [Spazi vettoriali](algebra-lineare/teoria/spazi-vettoriali.md)
+    - **Algebra Lineare** → [Spazi vettoriali](geometria-1/teoria/spazi-vettoriali.md)


### PR DESCRIPTION
## Summary
- Update homepage to link vector spaces notes under Geometria 1 instead of Algebra Lineare.

## Testing
- `mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_68961278e8b08326a6d7c64a87e68caf