### PR TITLE
test: ensure mkdocs nav paths exist

### DIFF
--- a/tests/test_nav_links.py
+++ b/tests/test_nav_links.py
@@ -1,0 +1,23 @@
+import yaml
+from pathlib import Path
+
+def extract_paths(nav):
+    paths = []
+    if isinstance(nav, list):
+        for item in nav:
+            paths.extend(extract_paths(item))
+    elif isinstance(nav, dict):
+        for value in nav.values():
+            paths.extend(extract_paths(value))
+    elif isinstance(nav, str) and nav.endswith('.md'):
+        paths.append(nav)
+    return paths
+
+
+def test_nav_links_exist():
+    config = yaml.safe_load(Path('mkdocs.yml').read_text())
+    nav = config.get('nav', [])
+    markdown_paths = extract_paths(nav)
+    docs_dir = Path('docs')
+    missing = [p for p in markdown_paths if not (docs_dir / p).exists()]
+    assert not missing, f"Missing markdown files: {missing}"


### PR DESCRIPTION
## Summary
- verify MkDocs `nav` entries point to existing markdown files

## Testing
- `pytest -q` *(fails: Missing markdown files as expected)*

------
https://chatgpt.com/codex/tasks/task_e_689612856a2883268e4b9a18928ad49b