### PR TITLE
Add workflow for MkDocs deployment

### DIFF
--- a/.github/workflows/deploy-mkdocs.yml
+++ b/.github/workflows/deploy-mkdocs.yml
@@ -1,0 +1,15 @@
+name: Deploy MkDocs
+on:
+  push:
+    branches: [main]  # o il branch dove fai i merge
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - run: pip install -r requirements.txt  # se hai un requirements.txt
+      - run: mkdocs gh-deploy --force        # pubblica su gh-pages


### PR DESCRIPTION
## Summary
- deploy mkdocs to `gh-pages` after pushes to `main`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6896192bd6b88326bb7fa0f88a36af6c