### PR TITLE
Fix vector space link and add prerequisites for Foglio 1

### DIFF
--- a/docs/geometria-1/esercizi/fogli/foglio-1.md
+++ b/docs/geometria-1/esercizi/fogli/foglio-1.md
@@ -1,5 +1,16 @@
 # Geometria I – Foglio 1
 
+## Prerequisiti
+
+- Definizione di spazio vettoriale e sue proprietà.
+- Operazioni tra vettori: somma, opposto e prodotto per scalare.
+- Sottospazi vettoriali.
+- Combinazioni lineari, span e dipendenza lineare.
+- Conoscenza di polinomi reali e matrici \(2\times 2\).
+
+!!! tip "Axio"
+    Ripassa le definizioni con esempi concreti: ti renderà più sicuro negli esercizi!
+
 ## Esercizio 1
 Dimostrare che in uno spazio vettoriale \(V\), abbiamo che \(0\cdot v = O\) per ogni \(v \in V\) (qui \(O \in V\) e \(0 \in \mathbb{R}\)) usando solo le altre proprietà della definizione di spazio vettoriale.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,9 @@ Il nostro viaggio non si ferma all'algebra lineare: nuove mete si aggiungeranno 
 ## Inizia il viaggio
 
 - **Analisi 1** → [Limiti](analisi-1/teoria/limiti.md)
-- **Geometria 1** → [Spazi vettoriali](geometria-1/teoria/spazi-vettoriali.md)
+- **Geometria 1**
+  - [Spazi vettoriali](geometria-1/teoria/spazi-vettoriali/index.md)
+  - [Foglio 1](geometria-1/esercizi/fogli/foglio-1.md)
 
 ---
 


### PR DESCRIPTION
## Summary
- Fix front page link to vector space hub and add quick access to Foglio 1.
- Introduce prerequisites section with Axio tip in Foglio 1 for Geometria I.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689632c24a8883269c7078d51dbd8240