### PR TITLE
feat: celebrate new domain and add hall of fame

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,8 @@
 
 Grazie per voler migliorare questa raccolta aperta di appunti. Con queste regole chiunque, anche senza esperienza di programmazione, può partecipare in modo semplice.
 
+Se non hai un account GitHub puoi inviare il materiale a [contributi@axiompaths.org](mailto:contributi@axiompaths.org).
+
 ## ✅ Passaggi per inviare un contributo
 1. **Forka** o usa l’editor online di GitHub: non servono strumenti particolari.
 2. **Crea o modifica** un file `.md` nella cartella corretta (`docs/…`).
@@ -66,4 +68,4 @@ Mantieni le pagine leggibili e piacevoli evitando eccessi grafici. Indici e home
 Quando può aiutare lo studio, inserisci link a teorie o esercizi correlati.
 
 ## ❓ Dubbi o problemi?
-Apri una [Issue](https://github.com/username/Axiom-Paths/issues).
+Apri una [Issue](https://github.com/username/Axiom-Paths/issues) oppure scrivi a [info@axiompaths.org](mailto:info@axiompaths.org).

--- a/README.md
+++ b/README.md
@@ -1,24 +1,33 @@
-# Axiom Paths
+# 🚀 Benvenuto su Axiom Paths – Ora su **axiompaths.org** ✨
 
-**Axiom Paths** è una raccolta open source di appunti, esercizi e risorse per studenti di matematica (università e oltre).
-Lo scopo è creare una **wiki collaborativa**, organizzata per corsi e argomenti, facile da navigare e sempre aggiornata.
+Abbiamo una nuova casa!  
+**Axiom Paths** è la wiki open source, creata da studenti per studenti, dove raccogliamo teoria, esercizi e appunti per affrontare (e superare!) gli esami universitari.
+
+📌 **Cosa trovi qui**  
+- Mini-ripassi teorici chiari e diretti.  
+- Esercizi ufficiali e prove d’esame, con soluzioni quando disponibili.  
+- Suggerimenti, errori comuni e sfide extra della nostra mascotte **Axio**.  
+
+🤝 **Come contribuire**  
+Se vuoi inviare appunti, esercizi o correzioni:
+- GitHub? Consulta la [guida per contribuire](CONTRIBUTING.md).
+- Non usi GitHub? Scrivi a [contributi@axiompaths.org](mailto:contributi@axiompaths.org).
+
+Per domande o informazioni generali:  
+📧 [info@axiompaths.org](mailto:info@axiompaths.org)
+
+> 📜 *Axiom Paths è un progetto peer-to-peer open source: non sostituiamo le fonti ufficiali, ma le integriamo con l’esperienza diretta di chi studia e contribuisce.*
+
+🌐 **Visita ora** → [https://axiompaths.org](https://axiompaths.org)
 
 ---
 
-## 📚 Cosa troverai qui
-- **Teoria**: spiegazioni concise con formule in LaTeX.
-- **Esercizi**: divisi per argomento, con soluzioni passo passo.
-- **Risorse extra**: link utili, mappe concettuali, esempi di esami.
+## 🏆 Hall of Fame
 
----
-
-## 🛠 Come contribuire
-Consulta la [guida per contribuire](CONTRIBUTING.md).
-
----
-
-## 🌐 Sito Web
-Il sito è disponibile all'indirizzo https://giovyx90.github.io/axiompaths/.
+| Utente | PR |
+| ------ | --: |
+| [giovyx90](https://github.com/giovyx90) | 61 |
+| `github-actions[bot]` | 1 |
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,10 +4,13 @@ Axio, la nostra mascotte, ti dà il benvenuto.
 
 > **Axiom Paths**: il percorso degli assiomi verso la comprensione.
 
+!!! info "Novità"
+    🎉 Ora abbiamo un nuovo dominio: [axiompaths.org](https://axiompaths.org) — Axio salta di gioia!
+
 !!! warning "Ricorda"
     Siamo studenti e possiamo sbagliare: mantieni sempre il pensiero critico!
 
-Axiom Paths è un progetto open-source che raccoglie appunti ed esercizi di matematica.  
+Axiom Paths è un progetto open-source che raccoglie appunti ed esercizi di matematica.
 Il nostro viaggio non si ferma all'algebra lineare: nuove mete si aggiungeranno lungo il cammino.
 
 ---

--- a/index.html
+++ b/index.html
@@ -1306,6 +1306,10 @@
 <blockquote>
 <p><strong>Axiom Paths</strong>: il percorso degli assiomi verso la comprensione.</p>
 </blockquote>
+<div class="admonition info">
+<p class="admonition-title">Novità</p>
+<p>🎉 Ora abbiamo un nuovo dominio: <a href="https://axiompaths.org">axiompaths.org</a> — Axio salta di gioia!</p>
+</div>
 <div class="admonition warning">
 <p class="admonition-title">Ricorda</p>
 <p>Siamo studenti e possiamo sbagliare: mantieni sempre il pensiero critico!</p>


### PR DESCRIPTION
## Summary
- announce new axiompaths.org domain in README and site index
- add email alternative for non-GitHub contributors
- introduce Hall of Fame for frequent PR authors

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689666e376208326b4c4ae9c8f1eec58