### PR TITLE
Add brief intros to math theory and exercise pages

### DIFF
--- a/docs/analisi-1/index.md
+++ b/docs/analisi-1/index.md
@@ -1,3 +1,8 @@
 # Analisi 1
 
+Questa sezione introduce i temi principali dell'analisi reale, con l'obiettivo di fornire strumenti per lo studio di limiti, derivate e integrali.
+
+!!! tip "Axio"
+    La pazienza nell'analisi ripaga: affronta un problema alla volta!
+
 🚧 Contenuti in arrivo.

--- a/docs/geometria-1/esercizi/fogli/foglio-1.md
+++ b/docs/geometria-1/esercizi/fogli/foglio-1.md
@@ -1,5 +1,7 @@
 # Geometria I – Foglio 1
 
+Primo foglio di esercizi per mettere in pratica i concetti base dell'algebra lineare.
+
 ## Prerequisiti
 
 - Definizione di spazio vettoriale e sue proprietà.

--- a/docs/geometria-1/esercizi/fogli/foglio-2.md
+++ b/docs/geometria-1/esercizi/fogli/foglio-2.md
@@ -1,5 +1,8 @@
 
 # Foglio 2
+
+Secondo foglio di esercizi dedicato a basi, dimensione e trasformazioni lineari.
+
 ## Prerequisiti
 
 - Basi e dimensione degli spazi vettoriali.

--- a/docs/geometria-1/esercizi/tematici/applicazioni-lineari-e-matrici.md
+++ b/docs/geometria-1/esercizi/tematici/applicazioni-lineari-e-matrici.md
@@ -1,5 +1,10 @@
 # Esercizi sulle Applicazioni Lineari e Matrici
 
+Pagina con esercizi per praticare trasformazioni lineari e matrici associate.
+
+!!! tip "Axio"
+    Analizza passo dopo passo: ogni operazione elementare svela la struttura nascosta della matrice.
+
 ## Obiettivo della tematica
 
 Allenare al calcolo di rango, nucleo e immagine di trasformazioni lineari mediante rappresentazioni matriciali.

--- a/docs/geometria-1/esercizi/tematici/spazi-vettoriali.md
+++ b/docs/geometria-1/esercizi/tematici/spazi-vettoriali.md
@@ -1,6 +1,11 @@
 # Esercizi sugli Spazi Vettoriali
 
-**Esercizio**  
+Breve raccolta di esercizi per consolidare le nozioni sugli spazi vettoriali.
+
+!!! tip "Axio"
+    Sperimenta strategie diverse: ogni esercizio è un'opportunità per scoprire nuovi collegamenti.
+
+**Esercizio**
 Dimostra che le seguenti terne di vettori in $\mathbb{R}^4$ sono linearmente indipendenti:
 
 $$

--- a/docs/geometria-1/teoria/basi-e-dimensione/basi.md
+++ b/docs/geometria-1/teoria/basi-e-dimensione/basi.md
@@ -1,5 +1,7 @@
 # Basi
 
+Studiamo le basi degli spazi vettoriali e come ogni vettore si rappresenta in modo unico.
+
 Un insieme ordinato di vettori di $V$ è una **base** se è linearmente indipendente
 e genera $V$.
 

--- a/docs/geometria-1/teoria/basi-e-dimensione/teoremi-sulle-basi.md
+++ b/docs/geometria-1/teoria/basi-e-dimensione/teoremi-sulle-basi.md
@@ -1,5 +1,7 @@
 # Teoremi sulle Basi
 
+Raccogliamo alcuni risultati utili per manipolare le basi e comprendere la dimensione.
+
 ## Insiemi massimali
 
 Un insieme $\{v_1,\dots,v_r\}\subseteq V$ è **massimale** se ogni altro

--- a/docs/geometria-1/teoria/spazi-vettoriali/combinazioni-lineari.md
+++ b/docs/geometria-1/teoria/spazi-vettoriali/combinazioni-lineari.md
@@ -1,5 +1,10 @@
 # Combinazioni Lineari e Dipendenza
 
+Scopriamo come combinare vettori e distinguere tra dipendenza e indipendenza lineare.
+
+!!! tip "Axio"
+    Prova a giocare con esempi concreti: aiutano a intuire quando i vettori collaborano o si annullano!
+
 Dati vettori $v_1,\dots,v_n\in V$ e scalari $x_1,\dots,x_n\in\mathbb{K}$,
 una **combinazione lineare** è
 

--- a/docs/geometria-1/teoria/spazi-vettoriali/definizioni.md
+++ b/docs/geometria-1/teoria/spazi-vettoriali/definizioni.md
@@ -1,5 +1,7 @@
 # Definizioni e Proprietà
 
+Introduciamo la definizione formale di spazio vettoriale e le proprietà che regolano le sue operazioni.
+
 Uno **spazio vettoriale** è una struttura $(V,+,\cdot)$ definita su un campo $\mathbb{K}$
 dotata di due operazioni:
 

--- a/docs/geometria-1/teoria/spazi-vettoriali/sottospazi.md
+++ b/docs/geometria-1/teoria/spazi-vettoriali/sottospazi.md
@@ -1,5 +1,10 @@
 # Sottospazi Vettoriali
 
+Vediamo come individuare i sottospazi di uno spazio vettoriale e perché ne preservano la struttura.
+
+!!! tip "Axio"
+    Pensa ai sottospazi come a piccoli mondi con le stesse regole del grande universo $V$!
+
 Un sottoinsieme $W \subseteq V$ è un **sottospazio** se:
 
 1. $v,w\in W \implies v+w \in W$.


### PR DESCRIPTION
## Summary
- add concise overview and Axio tip to Analisi 1 hub page
- introduce theory pages on combinazioni lineari and sottospazi with short summaries and mascot guidance
- provide brief introductions and motivational tips for several exercise collections and practice sheets

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68966e9cde6883269b0c43b247a2770b