### PR TITLE
Add guidelines page for exercises and theory

### DIFF
--- a/docs/guida-pagine.md
+++ b/docs/guida-pagine.md
@@ -1,0 +1,52 @@
+# 🧭 Guida alle Pagine di Esercizi e Teoria
+
+Questa pagina spiega come strutturare i contenuti su Axiom Paths, sia per chi scrive in semplice Markdown sia per chi utilizza \LaTeX.
+
+## Struttura consigliata
+
+1. **Introduzione breve**
+   - Presenta l'obiettivo della pagina in poche righe.
+2. **Contenuti ordinati**
+   - Suddividi teoria ed esercizi in sezioni chiare.
+   - Usa titoli `##` e `###` per una gerarchia leggibile.
+3. **Esempi e collegamenti**
+   - Inserisci esempi risolti e link a teorie correlate quando utili.
+
+## Indicazioni per Markdown
+
+- Mantieni uno stile conciso e didattico.
+- Se usi blocchi di codice o formule non inline, lascia una riga vuota sopra e sotto per migliorare la resa.
+- Le liste numerate e puntate aiutano a seguire il ragionamento passo passo.
+
+## Indicazioni per \LaTeX
+
+Per formule in linea usa `$a^2 + b^2 = c^2$`. Per blocchi separati utilizza `$$`:
+
+$$
+a^2 + b^2 = c^2
+$$
+
+Ricorda di lasciare una riga vuota prima e dopo il blocco come nell'esempio.
+
+!!! note "Axio suggerisce"
+    Allenati a spiegare ogni passaggio: capire a fondo un teorema rende gli esercizi più semplici.
+
+## Esempio di Pagina
+
+```markdown
+# Titolo dell'argomento
+
+Breve introduzione.
+
+## Teoria
+
+Contenuti teorici essenziali.
+
+## Esercizi
+
+1. Testo del primo esercizio.
+2. Secondo esercizio.
+```
+
+Questo schema può essere adattato a qualsiasi argomento e incoraggia una lettura chiara e progressiva.
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,6 +44,7 @@ extra_javascript:
 
 nav:
   - "🏠 Home": index.md
+  - "🛠️ Guida Pagine": guida-pagine.md
   - "📈 Analisi 1": analisi-1/index.md
   - "📐 Geometria 1":
       - "📚 Teoria":


### PR DESCRIPTION
## Summary
- add "Guida Pagine" outlining how to structure theory and exercise pages
- link new guide in root navigation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896724ba4348326aded422f889a0b2d