### PR TITLE
fix: render math before pdf generation

### DIFF
--- a/docs/js/download.js
+++ b/docs/js/download.js
@@ -8,7 +8,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const h1 = article.querySelector('h1');
   (h1?.parentNode || article).insertBefore(btn, h1?.nextSibling || article.firstChild);
 
-  btn.addEventListener('click', () => {
+  btn.addEventListener('click', async () => {
     const opt = {
       margin: 10,
       filename: (document.title || 'axiompaths') + '.pdf',
@@ -16,6 +16,15 @@ document.addEventListener('DOMContentLoaded', () => {
       html2canvas: { scale: 2, useCORS: true },
       jsPDF: { unit: 'mm', format: 'a4', orientation: 'portrait' }
     };
+
+    // Ensure MathJax and fonts are fully loaded before rendering the PDF
+    if (window.MathJax && MathJax.typesetPromise) {
+      await MathJax.typesetPromise();
+    }
+
+    if (document.fonts && document.fonts.ready) {
+      await document.fonts.ready;
+    }
 
     html2pdf()
       .set(opt)


### PR DESCRIPTION
## Summary
- ensure MathJax and fonts are fully loaded before exporting page to PDF

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896d26ed90c83268d12dd7a3c653159