### PR TITLE
Improve PDF generation for math and pagination

### DIFF
--- a/docs/js/download.js
+++ b/docs/js/download.js
@@ -13,8 +13,9 @@ document.addEventListener('DOMContentLoaded', () => {
       margin: 10,
       filename: (document.title || 'axiompaths') + '.pdf',
       image: { type: 'jpeg', quality: 0.98 },
-      html2canvas: { scale: 2, useCORS: true },
-      jsPDF: { unit: 'mm', format: 'a4', orientation: 'portrait' }
+      html2canvas: { scale: 2, useCORS: true, letterRendering: true },
+      jsPDF: { unit: 'mm', format: 'a4', orientation: 'portrait' },
+      pagebreak: { mode: ['css', 'legacy', 'avoid-all'] }
     };
 
     // Ensure MathJax and fonts are fully loaded before rendering the PDF

--- a/js/download.js
+++ b/js/download.js
@@ -13,8 +13,9 @@ document.addEventListener('DOMContentLoaded', () => {
       margin: 10,
       filename: (document.title || 'axiompaths') + '.pdf',
       image: { type: 'jpeg', quality: 0.98 },
-      html2canvas: { scale: 2, useCORS: true },
-      jsPDF: { unit: 'mm', format: 'a4', orientation: 'portrait' }
+      html2canvas: { scale: 2, useCORS: true, letterRendering: true },
+      jsPDF: { unit: 'mm', format: 'a4', orientation: 'portrait' },
+      pagebreak: { mode: ['css', 'legacy', 'avoid-all'] }
     };
 
     // Ensure MathJax and fonts are fully loaded before rendering the PDF


### PR DESCRIPTION
## Summary
- improve math rendering in generated PDFs by enabling letter-based rendering
- prevent awkward page splits with html2pdf pagebreak options

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896d663b70c83268cf27056e0ce8223