### PR TITLE
Fix KaTeX delimiters for bracket and inline math

### DIFF
--- a/js/katex.js
+++ b/js/katex.js
@@ -1,7 +1,9 @@
 document.addEventListener("DOMContentLoaded", function() {
   renderMathInElement(document.body, {
     delimiters: [
-      {left: "$$", right: "$$", display: true}
+      {left: "$$", right: "$$", display: true},
+      {left: "\\(", right: "\\)", display: false},
+      {left: "\\[", right: "\\]", display: true}
     ],
     throwOnError: false
   });


### PR DESCRIPTION
## Summary
- Support `\(` inline and `\[` display delimiters in KaTeX so LaTeX renders site-wide

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6896dc902bf48326a8d51ef0a2ab389f