### PR TITLE
Restrict KaTeX delimiters to bracket notation

### DIFF
--- a/docs/js/katex.js
+++ b/docs/js/katex.js
@@ -1,9 +1,8 @@
 document.addEventListener("DOMContentLoaded", function() {
   renderMathInElement(document.body, {
     delimiters: [
-      {left: "$$", right: "$$", display: true},
-      {left: "\(", right: "\)", display: false},
-      {left: "\[", right: "\]", display: true}
+      {left: "\\(", right: "\\)", display: false},
+      {left: "\\[", right: "\\]", display: true}
     ],
     throwOnError: false
   });

--- a/js/katex.js
+++ b/js/katex.js
@@ -1,7 +1,6 @@
 document.addEventListener("DOMContentLoaded", function() {
   renderMathInElement(document.body, {
     delimiters: [
-      {left: "$$", right: "$$", display: true},
       {left: "\\(", right: "\\)", display: false},
       {left: "\\[", right: "\\]", display: true}
     ],


### PR DESCRIPTION
## Summary
- simplify KaTeX auto-render configuration by using only `\(` and `\[` delimiters
- drop unused `$$` math markers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896dfd3d53483269e47b4d6ae138fde