### PR TITLE
Add internal cross-links across geometry pages

### DIFF
--- a/docs/geometria-1/esercizi/fogli/foglio-1.md
+++ b/docs/geometria-1/esercizi/fogli/foglio-1.md
@@ -4,11 +4,11 @@ Primo foglio di esercizi per mettere in pratica i concetti base dell'algebra lin
 
 ## Prerequisiti
 
-- Definizione di spazio vettoriale e sue proprietà.
-- Operazioni tra vettori: somma, opposto e prodotto per scalare.
-- Sottospazi vettoriali.
-- Combinazioni lineari, span e dipendenza lineare.
-- Conoscenza di polinomi reali e matrici \(2\times 2\).
+- [Definizione di spazio vettoriale e sue proprietà](../../teoria/spazi-vettoriali/definizioni.md).
+- [Operazioni tra vettori: somma, opposto e prodotto per scalare](../../teoria/spazi-vettoriali/definizioni.md).
+- [Sottospazi vettoriali](../../teoria/spazi-vettoriali/sottospazi.md).
+- [Combinazioni lineari, span e dipendenza lineare](../../teoria/spazi-vettoriali/combinazioni-lineari.md).
+- Conoscenza di polinomi reali e [matrici \(2\times 2\)](../../teoria/matrici/definizioni.md).
 
 !!! tip "Axio"
     Ripassa le definizioni con esempi concreti: ti renderà più sicuro negli esercizi!

--- a/docs/geometria-1/esercizi/tematici/spazi-vettoriali.md
+++ b/docs/geometria-1/esercizi/tematici/spazi-vettoriali.md
@@ -6,7 +6,7 @@ Breve raccolta di esercizi per consolidare le nozioni sugli spazi vettoriali.
     Sperimenta strategie diverse: ogni esercizio è un'opportunità per scoprire nuovi collegamenti.
 
 **Esercizio**
-Dimostra che le seguenti terne di vettori in $\mathbb{R}^4$ sono linearmente indipendenti:
+Dimostra che le seguenti terne di vettori in $\mathbb{R}^4$ sono [linearmente indipendenti](../../teoria/spazi-vettoriali/combinazioni-lineari.md):
 
 $$
 \left\{
@@ -56,7 +56,7 @@ $$
 
 *Prima terna.*
 
-Costruiamo la matrice $A$ con i vettori come colonne:
+Costruiamo la [matrice](../../teoria/matrici/definizioni.md) $A$ con i vettori come colonne:
 
 $$
 A = \begin{pmatrix}

--- a/docs/geometria-1/teoria/basi-e-dimensione/basi.md
+++ b/docs/geometria-1/teoria/basi-e-dimensione/basi.md
@@ -1,6 +1,6 @@
 # Basi
 
-Studiamo le basi degli spazi vettoriali e come ogni vettore si rappresenta in modo unico.
+Studiamo le basi degli [spazi vettoriali](../spazi-vettoriali/index.md) e come ogni vettore si rappresenta in modo unico.
 
 Un insieme ordinato di vettori di $V$ è una **base** se è linearmente indipendente
 e genera $V$.

--- a/docs/geometria-1/teoria/basi-e-dimensione/teoremi-sulle-basi.md
+++ b/docs/geometria-1/teoria/basi-e-dimensione/teoremi-sulle-basi.md
@@ -1,6 +1,6 @@
 # Teoremi sulle Basi
 
-Raccogliamo alcuni risultati utili per manipolare le basi e comprendere la dimensione.
+Raccogliamo alcuni risultati utili per manipolare le [basi](basi.md) e comprendere la dimensione.
 
 ## Insiemi massimali
 

--- a/docs/geometria-1/teoria/matrici/definizioni.md
+++ b/docs/geometria-1/teoria/matrici/definizioni.md
@@ -20,7 +20,7 @@ Date due matrici $A,B \in M_{m,n}(\mathbb{K})$ possiamo sommarle componente a co
 
 Per ogni scalare $c\in\mathbb{K}$, la matrice $cA$ si ottiene moltiplicando tutte le entrate di $A$ per $c$.
 
-Queste operazioni rendono $M_{m,n}(\mathbb{K})$ uno spazio vettoriale.
+Queste operazioni rendono $M_{m,n}(\mathbb{K})$ uno [spazio vettoriale](../spazi-vettoriali/index.md).
 
 ## Tipi di Matrici
 

--- a/docs/geometria-1/teoria/matrici/equazioni-lineari.md
+++ b/docs/geometria-1/teoria/matrici/equazioni-lineari.md
@@ -20,7 +20,7 @@ Il sistema è **omogeneo** se $b_1=\dots=b_m=0$; possiede sempre la soluzione ba
 
 Se $n>m$, il sistema omogeneo ammette sempre una soluzione non banale, cioè esistono $x_i$ non tutti nulli tali che $Ax=0$.
 
-Se $m=n$ e le colonne di $A$ sono linearmente indipendenti, allora il sistema $Ax=b$ ha una soluzione unica.
+Se $m=n$ e le colonne di $A$ sono [linearmente indipendenti](../spazi-vettoriali/combinazioni-lineari.md), allora il sistema $Ax=b$ ha una soluzione unica.
 
 !!! tip "Axio"
     Ogni sistema lineare è un enigma: cerca la chiave nascosta nelle sue colonne!


### PR DESCRIPTION
## Summary
- link basis theory to vector space hub
- reference base definition from basis theorems
- connect matrix and exercise pages to vector space and linear independence sections

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68971cf741d8832691ce3420947a82db