### PR TITLE
Rimuove blocchi di codice dalle formule

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -70,7 +70,8 @@ Le voci sono ordinate dalla più vecchia alla più recente.
 - 2025-08-09: Scorporata la pagina delle applicazioni generali e creata hub dedicata
 - 2025-08-09: Creato hub per gli esami calcolosi
 - 2025-08-09: Rimossi gli indent dei blocchi formula per il corretto rendering LaTeX
+- 2025-08-09: Eliminati blocchi di codice nelle pagine su moltiplicazione di matrici e spazi vettoriali
 ---
 !!! info "Aggiornamenti"
     **Data:** 2025-08-09
-    **Breve descrizione:** Aggiornata con la rimozione degli indent nelle formule in blocco.
+    **Breve descrizione:** Annotata la rimozione dei blocchi di codice e la sistemazione delle formule.

--- a/docs/geometria-1/teoria/matrici/moltiplicazione-tra-matrici.md
+++ b/docs/geometria-1/teoria/matrici/moltiplicazione-tra-matrici.md
@@ -40,7 +40,7 @@ per ogni \( i = 1, \dots, m \) e \( j = 1, \dots, p \).
     Ogni elemento \(c_{ij}\) è il **prodotto scalare** tra la riga \(i\) di \(A\) e la colonna \(j\) di \(B\):
 
 \[
-    c_{ij} = \langle \text{riga}_i(A), \, \text{colonna}_j(B) \rangle
+c_{ij} = \langle \text{riga}_i(A), \, \text{colonna}_j(B) \rangle
 \]
 
     Tuttavia, la moltiplicazione di matrici **nel suo insieme** non è un unico prodotto scalare, ma un insieme organizzato di tanti prodotti scalari.
@@ -51,7 +51,7 @@ per ogni \( i = 1, \dots, m \) e \( j = 1, \dots, p \).
     Se \(A\) è una matrice \(m \times n\) e vale
 
 \[
-    A X = 0 \quad \forall\, X \in \mathbb{K}^n
+A X = 0 \quad \forall\, X \in \mathbb{K}^n
 \]
 
     allora \(A = 0\).
@@ -61,7 +61,7 @@ per ogni \( i = 1, \dots, m \) e \( j = 1, \dots, p \).
     Il caso duale: se
 
 \[
-    Y^\top A = 0 \quad \forall\, Y \in \mathbb{K}^m
+Y^\top A = 0 \quad \forall\, Y \in \mathbb{K}^m
 \]
 
     allora \(A\) è nulla (tutte le righe nulle).
@@ -72,23 +72,23 @@ per ogni \( i = 1, \dots, m \) e \( j = 1, \dots, p \).
     Nella moltiplicazione di matrici non vale:
 
 \[
-    A \cdot B = 0 \ \Rightarrow\ A=0 \ \text{o}\ B=0
+A \cdot B = 0 \ \Rightarrow\ A=0 \ \text{o}\ B=0
 \]
 
     Esempio:
 
 \[
-    A =
-    \begin{pmatrix}
-    1 & -1 \\
-    1 & -1
-    \end{pmatrix},
-    \quad
-    B =
-    \begin{pmatrix}
-    1 & 1 \\
-    1 & 1
-    \end{pmatrix}
+A =
+\begin{pmatrix}
+1 & -1 \\
+1 & -1
+\end{pmatrix},
+\quad
+B =
+\begin{pmatrix}
+1 & 1 \\
+1 & 1
+\end{pmatrix}
 \]
 
     entrambi non nulli, ma \(A \cdot B = 0\).
@@ -120,10 +120,10 @@ Calcolo:
 
 \[
 \begin{aligned}
- c_{11} &= 2\cdot 1 + 1\cdot 0 + 0\cdot 2 = 2 \\
- c_{12} &= 2\cdot 4 + 1\cdot (-1) + 0\cdot 3 = 7 \\
- c_{21} &= (-1)\cdot 1 + 3\cdot 0 + 2\cdot 2 = 3 \\
- c_{22} &= (-1)\cdot 4 + 3\cdot (-1) + 2\cdot 3 = -1
+c_{11} &= 2\cdot 1 + 1\cdot 0 + 0\cdot 2 = 2 \\
+c_{12} &= 2\cdot 4 + 1\cdot (-1) + 0\cdot 3 = 7 \\
+c_{21} &= (-1)\cdot 1 + 3\cdot 0 + 2\cdot 2 = 3 \\
+c_{22} &= (-1)\cdot 4 + 3\cdot (-1) + 2\cdot 3 = -1
 \end{aligned}
 \]
 
@@ -194,5 +194,5 @@ A \cdot A^{-1} =
 
 !!! info "Aggiornamenti"
     **Data:** 2025-08-09
-    **Breve descrizione:** Rimossi gli indent dei blocchi formula per il corretto rendering.
+    **Breve descrizione:** Eliminati i blocchi di codice e sistemata la formattazione delle formule.
 

--- a/docs/geometria-1/teoria/spazi-vettoriali/definizioni.md
+++ b/docs/geometria-1/teoria/spazi-vettoriali/definizioni.md
@@ -21,49 +21,49 @@ Le operazioni rispettano le seguenti proprietà:
 1. **Associatività della somma**: per ogni $u,v,w\in V$,
 
 \[
-    (u+v)+w = u+(v+w)
+(u+v)+w = u+(v+w)
 \]
 
 2. **Elemento neutro della somma**: esiste $O\in V$ tale che
 
 \[
-    O+v = v+O = v
+O+v = v+O = v
 \]
 
 3. **Inverso additivo**: per ogni $v\in V$ esiste $-v\in V$ con
 
 \[
-    v+(-v)=O
+v+(-v)=O
 \]
 
 4. **Commutatività della somma**: per ogni $v,w\in V$,
 
 \[
-    v+w=w+v
+v+w=w+v
 \]
 
 5. **Distributività rispetto agli scalari**: per ogni $c\in\mathbb{K}$ e $u,v\in V$,
 
 \[
-    c(u+v)=cu+cv
+c(u+v)=cu+cv
 \]
 
 6. **Distributività degli scalari**: per ogni $a,b\in\mathbb{K}$ e $v\in V$,
 
 \[
-    (a+b)v=av+bv
+(a+b)v=av+bv
 \]
 
 7. **Associatività del prodotto per scalare**: per ogni $a,b\in\mathbb{K}$ e $v\in V$,
 
 \[
-    (ab)v=a(bv)
+(ab)v=a(bv)
 \]
 
 8. **Elemento neutro del prodotto per scalare**: per ogni $v\in V$,
 
 \[
-    1\cdot v = v
+1\cdot v = v
 \]
 
 ### Esempio: $\mathbb{K}^n$
@@ -86,5 +86,5 @@ Il vettore nullo è $(0,\dots,0)$.
 
 !!! info "Aggiornamenti"
     **Data:** 2025-08-09
-    **Breve descrizione:** Rimossi gli indent dei blocchi formula per il corretto rendering.
+    **Breve descrizione:** Eliminati i blocchi di codice e uniformata la formattazione delle formule.
 


### PR DESCRIPTION
## Summary
- Normalizzata la formattazione delle formule nella pagina sulla moltiplicazione tra matrici, eliminando i blocchi di codice indesiderati.
- Sistemate le formule nelle definizioni degli spazi vettoriali per evitare rendering in blocco.
- Aggiornato il changelog con le correzioni effettuate.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689762e3f5688326ae6701469648c77d