### PR TITLE
Add span theory page and update references

### DIFF
--- a/docs/geometria-1/esercizi/fogli/foglio-1.md
+++ b/docs/geometria-1/esercizi/fogli/foglio-1.md
@@ -7,7 +7,7 @@ Primo foglio di esercizi per mettere in pratica i concetti base dell'algebra lin
 - [Definizione di spazio vettoriale e sue proprietà](../../teoria/spazi-vettoriali/definizioni.md).
 - [Operazioni tra vettori: somma, opposto e prodotto per scalare](../../teoria/spazi-vettoriali/definizioni.md).
 - [Sottospazi vettoriali](../../teoria/spazi-vettoriali/sottospazi.md).
-- [Combinazioni lineari, span e dipendenza lineare](../../teoria/spazi-vettoriali/combinazioni-lineari.md).
+- [Combinazioni lineari e dipendenza](../../teoria/spazi-vettoriali/combinazioni-lineari.md) e [span](../../teoria/spazi-vettoriali/span.md).
 - Conoscenza di polinomi reali e [matrici \(2\times 2\)](../../teoria/matrici/definizioni.md).
 
 !!! tip "Axio"

--- a/docs/geometria-1/teoria/basi-e-dimensione/teoremi-sulle-basi.md
+++ b/docs/geometria-1/teoria/basi-e-dimensione/teoremi-sulle-basi.md
@@ -7,7 +7,7 @@ Raccogliamo alcuni risultati utili per manipolare le [basi](basi.md) e comprende
 Un insieme $\{v_1,\dots,v_r\}\subseteq V$ è **massimale** se ogni altro
 $v_i$ con $i>r$ rende dipendente l'insieme $\{v_1,\dots,v_r,v_i\}$.
 
-Per un ripasso su combinazioni lineari e span, vedi la sezione sugli [spazi vettoriali](../spazi-vettoriali/index.md).
+Per un ripasso su combinazioni lineari consulta [Combinazioni Lineari e Dipendenza](../spazi-vettoriali/combinazioni-lineari.md); per lo span vedi [Span](../spazi-vettoriali/span.md).
 
 !!! tip "Axio"
     Pensa a quali vettori sono davvero indispensabili: quelli superflui appesantiscono solo il bagaglio!

--- a/docs/geometria-1/teoria/matrici/rango-e-riduzione-di-gauss.md
+++ b/docs/geometria-1/teoria/matrici/rango-e-riduzione-di-gauss.md
@@ -7,7 +7,7 @@ Approfondiamo come i sistemi lineari si risolvono tramite la riduzione di Gauss 
 
 ## Dimensione dello Span
 
-Dato un insieme di vettori $v_1,\dots,v_k\in\mathbb{R}^n$, la dimensione del loro span è pari al numero di vettori linearmente indipendenti. Disporre i $v_i$ come colonne di una matrice e ridurla a scala permette di individuarli tramite i pivot.
+Dato un insieme di vettori $v_1,\dots,v_k\in\mathbb{R}^n$, la dimensione del loro [span](../spazi-vettoriali/span.md) è pari al numero di vettori linearmente indipendenti. Disporre i $v_i$ come colonne di una matrice e ridurla a scala permette di individuarli tramite i pivot.
 
 ## Iperpiani
 

--- a/docs/geometria-1/teoria/spazi-vettoriali/index.md
+++ b/docs/geometria-1/teoria/spazi-vettoriali/index.md
@@ -6,8 +6,9 @@ le loro proprietà e gli esempi più utili.
 ## Contenuti
 
 - [Definizioni e Proprietà](definizioni.md)
-- [Sottospazi](sottospazi.md)
 - [Combinazioni Lineari e Dipendenza](combinazioni-lineari.md)
+- [Span](span.md)
+- [Sottospazi](sottospazi.md)
 
 !!! tip "Axio"
     Ricorda: comprendere le regole fondamentali ti aiuta a maneggiare i vettori con sicurezza.

--- a/docs/geometria-1/teoria/spazi-vettoriali/span.md
+++ b/docs/geometria-1/teoria/spazi-vettoriali/span.md
@@ -1,0 +1,23 @@
+# Span
+
+Il **span** di un insieme di vettori è l'insieme di tutte le combinazioni lineari che essi generano.
+
+\[
+\operatorname{Span}(v_1,\dots,v_k)=\left\{\sum_{i=1}^k a_i v_i : a_i\in\mathbb{K}\right\}.
+\]
+
+!!! tip "Axio"
+    Ogni nuova combinazione è un passo in più verso la soluzione: esplora tutte le direzioni!
+
+## Esempi
+
+1. In \(\mathbb{R}^2\) i vettori \((1,0)\) e \((0,1)\) hanno come span l'intero spazio \(\mathbb{R}^2\).
+2. Il vettore \((1,1)\) genera la retta \(y=x\).
+3. In \(\mathbb{R}^3\) i vettori \((1,0,0)\) e \((0,1,0)\) generano il piano \(xy\).
+
+---
+
+!!! info "Aggiornamenti"
+    **Data:** 2025-08-10
+    **Breve descrizione:** Creata la pagina introduttiva sullo span.
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -60,8 +60,9 @@ nav:
           - Spazi Vettoriali:
               - Introduzione: geometria-1/teoria/spazi-vettoriali/index.md
               - Definizioni e Proprietà: geometria-1/teoria/spazi-vettoriali/definizioni.md
-              - Sottospazi: geometria-1/teoria/spazi-vettoriali/sottospazi.md
               - Combinazioni Lineari e Dipendenza: geometria-1/teoria/spazi-vettoriali/combinazioni-lineari.md
+              - Span: geometria-1/teoria/spazi-vettoriali/span.md
+              - Sottospazi: geometria-1/teoria/spazi-vettoriali/sottospazi.md
           - Basi e Dimensione:
               - Introduzione: geometria-1/teoria/basi-e-dimensione/index.md
               - Basi: geometria-1/teoria/basi-e-dimensione/basi.md


### PR DESCRIPTION
## Summary
- add introductory span page with examples and Axio tip
- link span page in spazi vettoriali hub and site navigation
- update related theory and exercise pages to reference span

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6898af79bb5c8326a58d5dcde7d4ac1a