### PR TITLE
feat: add Learning Paths section with initial guides

### DIFF
--- a/docs/assets/paths.css
+++ b/docs/assets/paths.css
@@ -1,0 +1,4 @@
+/* Stili per la sezione Learning Paths */
+.path-card { border: 1px solid #eee; padding: 1rem; border-radius: 8px; }
+.path-badge { background: #e0f2ff; color: #0366d6; padding: 0.2rem 0.5rem; border-radius: 4px; font-size: 0.8rem; }
+.final-lap { border-left: 4px solid #ffd54f; padding-left: 0.5rem; }

--- a/docs/assets/paths.js
+++ b/docs/assets/paths.js
@@ -1,0 +1,7 @@
+// Piccoli toggle per hint/errori comuni
+function toggleSection(id) {
+  var el = document.getElementById(id);
+  if (el) {
+    el.hidden = !el.hidden;
+  }
+}

--- a/docs/data/modules.yml
+++ b/docs/data/modules.yml
@@ -1,0 +1,24 @@
+- id: RREF
+  name: Riduzione di Gauss (RREF)
+  theory: ["/hub/matrici#operazioni-elementari"]
+- id: RankRead
+  name: Lettura del rango
+  theory: ["/hub/rango-nullita"]
+- id: RC
+  name: Teorema di Rouché–Capelli
+  theory: ["/hub/rango-nullita#rouche-capelli"]
+- id: BasisExtract
+  name: Estrazione base (da span o da N(A))
+  theory: ["/hub/basi-dimensione"]
+- id: ChangeOfBasis
+  name: Cambio di base
+  theory: ["/hub/basi-dimensione#cambio-di-base"]
+- id: LinCheck
+  name: Test di linearità
+  theory: ["/hub/applicazioni-lineari#linearita"]
+- id: KernelSolve
+  name: Ker(T) come soluzione di Tx=0
+  theory: ["/hub/applicazioni-lineari#ker-im"]
+- id: ImagePivot
+  name: Im(T) da colonne pivot
+  theory: ["/hub/applicazioni-lineari#ker-im"]

--- a/docs/geometria-1/teoria/applicazioni-lineari/index.md
+++ b/docs/geometria-1/teoria/applicazioni-lineari/index.md
@@ -9,8 +9,13 @@ Le **applicazioni lineari** collegano spazi vettoriali preservando la struttura 
 !!! tip "Axio"
     Trasforma problemi complessi in linee rette: la linearità è tua alleata!
 
+!!! note "Vai ai Learning Paths collegati"
+    - [AL-04 — Definire T: linearità e matrice](../../../paths/lp-al-04.md)
+    - [KI-05 — Ker, Im, Rank–Nullity, classificazione](../../../paths/lp-ki-05.md)
+    - [CB-03 — Cambio di base (vettori e matrici)](../../../paths/lp-cb-03.md)
+
 ---
 
 !!! info "Aggiornamenti"
-    **Data:** 2025-08-09
-    **Breve descrizione:** Riorganizzata come hub delle applicazioni lineari dopo la separazione dalle applicazioni generali.
+    **Data:** 2025-08-10
+    **Breve descrizione:** Aggiunti link ai Learning Paths.

--- a/docs/geometria-1/teoria/spazi-vettoriali/index.md
+++ b/docs/geometria-1/teoria/spazi-vettoriali/index.md
@@ -13,9 +13,13 @@ le loro proprietà e gli esempi più utili.
 !!! tip "Axio"
     Ricorda: comprendere le regole fondamentali ti aiuta a maneggiare i vettori con sicurezza.
 
+!!! note "Vai ai Learning Paths collegati"
+    - [SV-01 — Sottospazi, base e dimensione](../../../paths/lp-sv-01.md)
+    - [SV-02 — Indipendenza, span e completamento a base](../../../paths/lp-sv-02.md)
+
 ---
 
 !!! info "Aggiornamenti"
-    **Data:** 2025-08-09  
-    **Breve descrizione:** Inizio tracciamento delle modifiche.
+    **Data:** 2025-08-10  
+    **Breve descrizione:** Aggiunti link ai Learning Paths.
 

--- a/docs/paths/index.md
+++ b/docs/paths/index.md
@@ -1,0 +1,21 @@
+# Learning Paths
+
+Percorsi guidati per risolvere i macro-tipi di esercizi da **Spazi vettoriali** ad **Applicazioni lineari**.
+
+> Ogni Path = obiettivo, input, laps operativi, grafico e "errori comuni".
+
+!!! tip "Axio"
+    Scegli il percorso che ti serve e affrontalo un lap alla volta!
+
+**Start veloci**
+- [SV-01 — Sottospazi, base e dimensione](lp-sv-01.md)
+- [SV-02 — Indipendenza, span e completamento a base](lp-sv-02.md)
+- [CB-03 — Cambio di base (vettori e matrici)](lp-cb-03.md)
+- [AL-04 — Definire T: linearità e matrice](lp-al-04.md)
+- [KI-05 — Ker, Im, Rank–Nullity, classificazione](lp-ki-05.md)
+
+---
+
+!!! info "Aggiornamenti"
+    **Data:** 2025-08-10
+    **Breve descrizione:** Creata panoramica dei Learning Paths.

--- a/docs/paths/lp-al-04.md
+++ b/docs/paths/lp-al-04.md
@@ -1,0 +1,27 @@
+---
+title: "LP-AL-04 — Definire T: linearità e matrice"
+goal: "Verificare linearità e costruire [T]_{B,B′}; applicare T a un vettore."
+inputs: ["Definizione di T (formula o valori su base)", "Basi B di V e B' di W"]
+tags: ["Applicazioni lineari"]
+path_expr: "(GivenOnBasis | GivenByFormula) > LinearityCheck > ColumnsFromImages > MatrixAssemble > ActionOnVector > Wrap"
+links: ["/hub/applicazioni-lineari#linearita", "/hub/applicazioni-lineari#rappresentazione-matriciale"]
+---
+
+Costruisci la matrice di un'applicazione lineare e verifica che sia davvero lineare.
+
+!!! tip "Axio"
+    Una matrice è la foto di $T$ in due basi: assicurati che le immagini siano nella base del codominio.
+
+**Lap**  
+1) *LinearityCheck*: additività + omogeneità.  
+2) *ColumnsFromImages*: esprimi $T(b_i)$ in $B'$ ⇒ colonne.  
+3) *MatrixAssemble*: monta $[T]_{B,B'}$.  
+4) *ActionOnVector*: $[T(x)]_{B'} = [T] \cdot [x]_B$.
+
+Errori comuni: immagini non espresse nella base del codominio; usare vettori non di base per definire colonne.
+
+---
+
+!!! info "Aggiornamenti"
+    **Data:** 2025-08-10
+    **Breve descrizione:** Aggiunto percorso LP-AL-04.

--- a/docs/paths/lp-cb-03.md
+++ b/docs/paths/lp-cb-03.md
@@ -1,0 +1,39 @@
+---
+title: "LP-CB-03 — Cambio di base (vettori e matrici)"
+goal: "Costruire P di cambio base e convertire coordinate; aggiornare [T]."
+inputs: ["B=(b1,…,bn), B'=(b1',…,bn')", "Opz.: [T]_B, [v]_B"]
+tags: ["Basi & Dimensione","Applicazioni lineari"]
+path_expr: "ValidateBases > BuildP > InvertP > (VectorCoords | MapUpdate) > Wrap"
+links: ["/hub/basi-dimensione#cambio-di-base", "/hub/applicazioni-lineari#rappresentazione-matriciale"]
+---
+
+Impara a passare da una base all'altra costruendo le matrici di cambio base e aggiornando coordinate e rappresentazioni.
+
+!!! tip "Axio"
+    Controlla sempre il verso della freccia: stai passando da $B$ a $B'$ o viceversa?
+
+**Lap**  
+1) *ValidateBases*: verifica che $B$, $B'$ siano basi (indipendenti).  
+2) *BuildP*: colonne = $\text{coord}_B(b_i')$.  
+3) *InvertP*: ottieni $P^{-1}$.  
+4) *VectorCoords*: $[v]_{B'} = P^{-1}[v]_B$.  
+5) *MapUpdate*: $[T]_{B'} = P^{-1}[T]_B P$ (se $B'$ su dominio e codominio coincidenti).
+
+```mermaid
+flowchart TD
+  A[ValidateBases] --> B[BuildP]
+  B --> C[InvertP]
+  C --> D{Vector o mappa?}
+  D -->|Vettore| E[VectorCoords]
+  D -->|Mappa| F[MapUpdate]
+  E --> G[Wrap]
+  F --> G
+```
+
+Errori comuni: verso del cambio ($B\leftarrow B'$); dimenticare che le colonne di $P$ sono le coord di $B'$ **rispetto a** $B$.
+
+---
+
+!!! info "Aggiornamenti"
+    **Data:** 2025-08-10
+    **Breve descrizione:** Aggiunto percorso LP-CB-03.

--- a/docs/paths/lp-ki-05.md
+++ b/docs/paths/lp-ki-05.md
@@ -1,0 +1,27 @@
+---
+title: "LP-KI-05 — Ker, Im, Rank–Nullity e classificazione"
+goal: "Dalla matrice di T: Ker, Im, rango/nullità; decidere iniettiva/suriettiva/isomorfismo."
+inputs: ["[T]_{B,B’} oppure definizione di T + basi"]
+tags: ["Applicazioni lineari","Basi & Dimensione"]
+path_expr: "MatrixRep > KernelSolve > ImageBasis > RankNullityCheck > Classify > (InvertIfIso?) > Wrap"
+links: ["/hub/applicazioni-lineari#ker-im", "/hub/basi-dimensione#teorema-rango-nullita"]
+---
+
+Usa la matrice di un'applicazione per studiarne nucleo, immagine e proprietà di iniettività o suriettività.
+
+!!! tip "Axio"
+    Se trovi tutti pivot possibili, stai forse osservando un isomorfismo!
+
+**Lap**  
+1) *KernelSolve*: $Tx=0$ → base(Ker), $\dim(\ker T)$.  
+2) *ImageBasis*: RREF($[T]$) → colonne pivot = base(Im), $\operatorname{rk}(T)$.  
+3) *RankNullityCheck*: $\dim(V)=\operatorname{rk}+\text{null}$.  
+4) *Classify*: null=0 ⇒ iniettiva; rk=dim W ⇒ suriettiva; se $\dim V=\dim W$ e bijettiva ⇒ isomorfismo (calcola $T^{-1}$ con Gauss su $[T|I]$).
+
+Errori comuni: leggere pivot nella matrice sbagliata; non esprimere Im(T) nella base del codominio.
+
+---
+
+!!! info "Aggiornamenti"
+    **Data:** 2025-08-10
+    **Breve descrizione:** Aggiunto percorso LP-KI-05.

--- a/docs/paths/lp-sv-01.md
+++ b/docs/paths/lp-sv-01.md
@@ -1,0 +1,39 @@
+---
+title: "LP-SV-01 — Sottospazi, base e dimensione"
+goal: "Dato W⊆V, decidere se è sottospazio e trovarne base e dimensione."
+inputs: ["Spazio V su K", "Descrizione di W: span{v_i} oppure vincoli Ax=0"]
+tags: ["Spazi vettoriali","Basi & Dimensione"]
+path_expr: "ModelSpace > NormalizeW > SubspaceTest > (SpanRoute | ConstraintRoute) > BasisW > DimRead > Wrap"
+links: ["/hub/spazi-vettoriali", "/hub/basi-dimensione", "/hub/matrici#rref"]
+---
+
+Mini percorso per verificare se un sottoinsieme è sottospazio e ricavarne base e dimensione.
+
+!!! tip "Axio"
+    Mettere ordine è il primo passo: normalizza sempre la descrizione di $W$.
+
+**Lap**  
+1) *ModelSpace*: fissa V, K, coordinate.  
+2) *NormalizeW*: uniforma W (lista generatori **o** $A x=0$).  
+3) *SubspaceTest*: $0\in W$ e chiusura? (altrimenti → "Non sottospazio").  
+4) *SpanRoute* **oppure** *ConstraintRoute*: RREF su $[v_1\dots v_k]$ **oppure** su $A$.  
+5) *BasisW*: estrai base (colonne pivot / parametri liberi).  
+6) *DimRead*: $\dim(W) =$ #vettori di base.
+
+```mermaid
+flowchart TD
+  A[NormalizeW] --> B{W=Span o Ax=0?}
+  B -->|Span| C[RREF su [v1…vk]]
+  B -->|Ax=0| D[RREF su A]
+  C --> E[Base(W)]
+  D --> E
+  E --> F[dim(W)]
+```
+
+Errori comuni: confondere #equazioni con $\dim(W)$; contare pivot sulla matrice sbagliata.
+
+---
+
+!!! info "Aggiornamenti"
+    **Data:** 2025-08-10
+    **Breve descrizione:** Aggiunto percorso LP-SV-01.

--- a/docs/paths/lp-sv-02.md
+++ b/docs/paths/lp-sv-02.md
@@ -1,0 +1,38 @@
+---
+title: "LP-SV-02 — Indipendenza, span e completamento a base"
+goal: "Dato S={v1,…,vk}, decidere indipendenza, base(Span S), completare a base(V), e coordinatizzare v."
+inputs: ["Vettori in K^n", "Opz.: vettore v da esprimere"]
+tags: ["Spazi vettoriali","Basi & Dimensione"]
+path_expr: "Collect > MatrixCols > RREF > PivotRead > (ExtractBase | CompleteToBasis) > (Coords? > SolveCoords : Skip) > Wrap"
+links: ["/hub/basi-dimensione", "/hub/matrici#rref"]
+---
+
+Scopri se un insieme di vettori è indipendente e come completarlo a base del vettore ambiente.
+
+!!! tip "Axio"
+    Se un vettore non è nei pivot, chiediti se puoi aggiungerlo per completare la tua base.
+
+**Lap**  
+1) *MatrixCols*: $M=[v_1\dots v_k]$.  
+2) *RREF* → *PivotRead*: colonne pivot ⇒ indipendenti.  
+3) *ExtractBase*: base(Span S) = colonne originali corrispondenti ai pivot.  
+4) *CompleteToBasis*: se serve base(V), aggiungi vettori finché hai $n$ pivot.  
+5) *SolveCoords*: risolvi $M c = v$ (se compatibile).
+
+```mermaid
+flowchart TD
+  A[MatrixCols] --> B[RREF]
+  B --> C[PivotRead]
+  C --> D[ExtractBase]
+  C --> E[CompleteToBasis]
+  D --> F[SolveCoords]
+  E --> F
+```
+
+Errori comuni: usare colonne della RREF invece delle originali; chiedere coordinate se $v\notin \text{Span }S$.
+
+---
+
+!!! info "Aggiornamenti"
+    **Data:** 2025-08-10
+    **Breve descrizione:** Aggiunto percorso LP-SV-02.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,105 +1,106 @@
 site_name: Axiom Paths
 site_description: Wiki open-source di matematica, esercizi e appunti
 repo_url: https://github.com/giovyx90/axiompaths
-
 theme:
   name: material
   palette:
-    - scheme: default
-      primary: blue
-      accent: indigo
-    - scheme: slate
-      primary: blue
-      accent: indigo
+  - scheme: default
+    primary: blue
+    accent: indigo
+  - scheme: slate
+    primary: blue
+    accent: indigo
   font:
     text: Inter
   features:
-    - navigation.instant
-    - navigation.sections
-    - navigation.indexes
-    - toc.integrate
-    - search.suggest
-    - search.highlight
-    - content.code.copy
-# niente logo: usiamo solo il nome
-# logo:   ← rimosso
-
+  - navigation.instant
+  - navigation.sections
+  - navigation.indexes
+  - toc.integrate
+  - search.suggest
+  - search.highlight
+  - content.code.copy
 extra_css:
-  - stylesheets/extra.css
-  - https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css
-  - styles/print.css
+- stylesheets/extra.css
+- https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css
+- styles/print.css
+- assets/paths.css
 markdown_extensions:
-  - admonition
-  - codehilite
-  - footnotes
-  - meta
-  - toc:
-      permalink: true
-  - pymdownx.arithmatex:
-      generic: true
-  - pymdownx.superfences
-  - pymdownx.details
-
+- admonition
+- codehilite
+- footnotes
+- meta
+- toc:
+    permalink: true
+- pymdownx.arithmatex:
+    generic: true
+- pymdownx.superfences
+- pymdownx.details
 extra_javascript:
-  - https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js
-  - https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/contrib/auto-render.min.js
-  - js/katex.js
-  - https://cdn.jsdelivr.net/npm/html2pdf.js@0.10.1/dist/html2pdf.bundle.min.js
-  - js/download.js
-
-  
-
+- https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js
+- https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/contrib/auto-render.min.js
+- js/katex.js
+- https://cdn.jsdelivr.net/npm/html2pdf.js@0.10.1/dist/html2pdf.bundle.min.js
+- js/download.js
+- assets/paths.js
 nav:
-  - "🏠 Home": index.md
-  - "🛠️ Guida Pagine": guida-pagine.md
-  - "🧩 Axio Quest": quest/soluzioni-axio-quest.md
-  - "🌟 Axiom Paths Originals":
-      - "📘 Teoria": axiom-paths-originals/teoria.md
-      - "📄 Esami": geometria-1/esami/axiom-paths-originals/index.md
-      - "🕑 Coming soon": axiom-paths-originals/coming-soon.md
-  - "🕒 Changelog": changelog.md
-  - "📈 Analisi 1": analisi-1/index.md
-  - "📐 Geometria 1":
-      - "📚 Teoria":
-          - geometria-1/teoria/index.md
-          - Spazi Vettoriali:
-              - Definizioni e Proprietà: geometria-1/teoria/spazi-vettoriali/definizioni.md
-              - Combinazioni Lineari e Dipendenza: geometria-1/teoria/spazi-vettoriali/combinazioni-lineari.md
-              - Span: geometria-1/teoria/spazi-vettoriali/span.md
-              - Sottospazi: geometria-1/teoria/spazi-vettoriali/sottospazi.md
-          - Basi e Dimensione:
-              - Basi: geometria-1/teoria/basi-e-dimensione/basi.md
-              - Teoremi sulle Basi: geometria-1/teoria/basi-e-dimensione/teoremi-sulle-basi.md
-              - Teorema di Grassmann: geometria-1/teoria/basi-e-dimensione/teorema-di-grassmann.md
-          - Matrici:
-              - Definizioni e Operazioni: geometria-1/teoria/matrici/definizioni.md
-              - Moltiplicazione tra Matrici: geometria-1/teoria/matrici/moltiplicazione-tra-matrici.md
-              - Inversa di una Matrice: geometria-1/teoria/matrici/inversa.md
-              - Equazioni Lineari: geometria-1/teoria/matrici/equazioni-lineari.md
-              - Rango e Riduzione di Gauss: geometria-1/teoria/matrici/rango-e-riduzione-di-gauss.md
-              - Determinante: geometria-1/teoria/matrici/determinante.md
-          - Applicazioni:
-              - Applicazioni Lineari:
-                  - Definizione e Proprietà: geometria-1/teoria/applicazioni-lineari/definizione-e-proprieta.md
-          - Autovalori e Autovettori: geometria-1/teoria/autovalori-e-autovettori/index.md
-          - Forme Canoniche e Jordan: geometria-1/teoria/forme-canoniche-e-jordan/index.md
-          - Duali e Forme Bilineari: geometria-1/teoria/duali-e-forme-bilineari/index.md
-          - Prodotto Scalare e Ortonormalità: geometria-1/teoria/prodotto-scalare-e-ortonormalita/index.md
-          - Teoremi Classici della Geometria Proiettiva: geometria-1/teoria/teoremi-classici-geometria-proiettiva/index.md
-      - "📝 Esercizi":
-          - Tematici:
-              - Spazi Vettoriali: geometria-1/esercizi/tematici/spazi-vettoriali.md
-              - Basi e Dimensione: geometria-1/esercizi/tematici/basi-e-dimensione.md
-              - Applicazioni Lineari: geometria-1/esercizi/tematici/applicazioni-lineari-e-matrici.md
-          - Fogli:
-              - Foglio 1: geometria-1/esercizi/fogli/foglio-1.md
-              - Foglio 2: geometria-1/esercizi/fogli/foglio-2.md
-              - Foglio 3: geometria-1/esercizi/fogli/foglio-3.md
-      - "🎓 Esami":
-          - geometria-1/esami/index.md
-          - Calcoloso: geometria-1/esami/calcoloso/index.md
-          - Teorico: geometria-1/esami/teorico/index.md
-          - Bomber: geometria-1/esami/bomber/index.md
-          - Trasversale: geometria-1/esami/trasversale/index.md
-          - Lunga Durata: geometria-1/esami/lunga-durata/index.md
-          - Axiom Paths Originals: geometria-1/esami/axiom-paths-originals/index.md
+- 🏠 Home: index.md
+- 🛠️ Guida Pagine: guida-pagine.md
+- 🧩 Axio Quest: quest/soluzioni-axio-quest.md
+- 🎯 Learning Paths:
+  - Panoramica: paths/index.md
+  - SV-01 — Sottospazi, base e dimensione: paths/lp-sv-01.md
+  - SV-02 — Indipendenza, span e completamento a base: paths/lp-sv-02.md
+  - 'CB-03 — Cambio di base: vettori e matrici': paths/lp-cb-03.md
+  - 'AL-04 — Definire T: linearità e matrice': paths/lp-al-04.md
+  - KI-05 — Ker, Im, Rank–Nullity, classificazione: paths/lp-ki-05.md
+- 🌟 Axiom Paths Originals:
+  - 📘 Teoria: axiom-paths-originals/teoria.md
+  - 📄 Esami: geometria-1/esami/axiom-paths-originals/index.md
+  - 🕑 Coming soon: axiom-paths-originals/coming-soon.md
+- 🕒 Changelog: changelog.md
+- 📈 Analisi 1: analisi-1/index.md
+- 📐 Geometria 1:
+  - 📚 Teoria:
+    - geometria-1/teoria/index.md
+    - Spazi Vettoriali:
+      - Definizioni e Proprietà: geometria-1/teoria/spazi-vettoriali/definizioni.md
+      - Combinazioni Lineari e Dipendenza: geometria-1/teoria/spazi-vettoriali/combinazioni-lineari.md
+      - Span: geometria-1/teoria/spazi-vettoriali/span.md
+      - Sottospazi: geometria-1/teoria/spazi-vettoriali/sottospazi.md
+    - Basi e Dimensione:
+      - Basi: geometria-1/teoria/basi-e-dimensione/basi.md
+      - Teoremi sulle Basi: geometria-1/teoria/basi-e-dimensione/teoremi-sulle-basi.md
+      - Teorema di Grassmann: geometria-1/teoria/basi-e-dimensione/teorema-di-grassmann.md
+    - Matrici:
+      - Definizioni e Operazioni: geometria-1/teoria/matrici/definizioni.md
+      - Moltiplicazione tra Matrici: geometria-1/teoria/matrici/moltiplicazione-tra-matrici.md
+      - Inversa di una Matrice: geometria-1/teoria/matrici/inversa.md
+      - Equazioni Lineari: geometria-1/teoria/matrici/equazioni-lineari.md
+      - Rango e Riduzione di Gauss: geometria-1/teoria/matrici/rango-e-riduzione-di-gauss.md
+      - Determinante: geometria-1/teoria/matrici/determinante.md
+    - Applicazioni:
+      - Applicazioni Lineari:
+        - Definizione e Proprietà: geometria-1/teoria/applicazioni-lineari/definizione-e-proprieta.md
+    - Autovalori e Autovettori: geometria-1/teoria/autovalori-e-autovettori/index.md
+    - Forme Canoniche e Jordan: geometria-1/teoria/forme-canoniche-e-jordan/index.md
+    - Duali e Forme Bilineari: geometria-1/teoria/duali-e-forme-bilineari/index.md
+    - Prodotto Scalare e Ortonormalità: geometria-1/teoria/prodotto-scalare-e-ortonormalita/index.md
+    - Teoremi Classici della Geometria Proiettiva: geometria-1/teoria/teoremi-classici-geometria-proiettiva/index.md
+  - 📝 Esercizi:
+    - Tematici:
+      - Spazi Vettoriali: geometria-1/esercizi/tematici/spazi-vettoriali.md
+      - Basi e Dimensione: geometria-1/esercizi/tematici/basi-e-dimensione.md
+      - Applicazioni Lineari: geometria-1/esercizi/tematici/applicazioni-lineari-e-matrici.md
+    - Fogli:
+      - Foglio 1: geometria-1/esercizi/fogli/foglio-1.md
+      - Foglio 2: geometria-1/esercizi/fogli/foglio-2.md
+      - Foglio 3: geometria-1/esercizi/fogli/foglio-3.md
+  - 🎓 Esami:
+    - geometria-1/esami/index.md
+    - Calcoloso: geometria-1/esami/calcoloso/index.md
+    - Teorico: geometria-1/esami/teorico/index.md
+    - Bomber: geometria-1/esami/bomber/index.md
+    - Trasversale: geometria-1/esami/trasversale/index.md
+    - Lunga Durata: geometria-1/esami/lunga-durata/index.md
+    - Axiom Paths Originals: geometria-1/esami/axiom-paths-originals/index.md


### PR DESCRIPTION
## Summary
- add Learning Paths section with 5 guided paths from spaces to linear maps
- register reusable theory modules and lightweight styles for paths
- update navigation with new section and link hubs to relevant paths

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689d03964aac83269cd1c1be37fbac45